### PR TITLE
fix(Warnings): Deprecated innerRef

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^4.0.0",
     "scrollreveal": "^4.0.0",
-    "styled-components": "^3.4.5"
+    "styled-components": "^4.1.2"
   },
   "peerDependencies": {
     "react": "^15.0.0-0 || ^16.0.0-0"

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,6 @@ class Snuggle extends React.PureComponent<PropType> {
       const itemProps = removeBlackListed({
         ...item.props,
         ref: refItem,
-        innerRef: refItem,
         key: key()
       })
 


### PR DESCRIPTION
Clears the following warning:
 ```The "innerRef" API has been removed in styled-components v4 in favor of React 16 ref forwarding, use "ref" instead like a typical component. "innerRef" was detected on component "Styled(styled.div)".```

According to: https://github.com/styled-components/styled-components/blob/master/CHANGELOG.md